### PR TITLE
Signal and typewriter rework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 sourcemap.json
+Narugoku Shipgundam.rbxl

--- a/src/ReplicatedStorage/Modules/Store.lua
+++ b/src/ReplicatedStorage/Modules/Store.lua
@@ -5,5 +5,5 @@ local Signal = require(ReplicatedStorage.Modules.Utility.Signal)
 
 return {
 	Frames = nil,
-	PopulatedFrames = Signal.New(),
+	PopulatedFrames = Signal.new(),
 }

--- a/src/ReplicatedStorage/Modules/Utility/Signal.lua
+++ b/src/ReplicatedStorage/Modules/Utility/Signal.lua
@@ -1,49 +1,183 @@
-local Signal = {}
-local Dis = {}
-Signal.__index = Signal
-Dis.__index = Dis
+-- Forked: https://github.com/stravant/goodsignal
 
-function Signal.New()
-	local Info = setmetatable( {
-		Callbacks = {},
-	} , Signal )
-	return Info
+
+--------------------------------------------------------------------------------
+--               Batched Yield-Safe Signal Implementation                     --
+-- This is a Signal class which has effectively identical behavior to a       --
+-- normal RBXScriptSignal, with the only difference being a couple extra      --
+-- stack frames at the bottom of the stack trace when an error is thrown.     --
+-- This implementation caches runner coroutines, so the ability to yield in   --
+-- the signal handlers comes at minimal extra cost over a naive signal        --
+-- implementation that either always or never spawns a thread.                --
+--                                                                            --
+-- API:                                                                       --
+--   local Signal = require(THIS MODULE)                                      --
+--   local sig = Signal.new()                                                 --
+--   local connection = sig:Connect(function(arg1, arg2, ...) ... end)        --
+--   sig:Fire(arg1, arg2, ...)                                                --
+--   connection:Disconnect()                                                  --
+--   sig:DisconnectAll()                                                      --
+--   local arg1, arg2, ... = sig:Wait()                                       --
+--                                                                            --
+-- Licence:                                                                   --
+--   Licenced under the MIT licence.                                          --
+--                                                                            --
+-- Authors:                                                                   --
+--   stravant - July 31st, 2021 - Created the file.                           --
+--------------------------------------------------------------------------------
+
+-- The currently idle thread to run the next handler on
+local freeRunnerThread = nil
+
+-- Function which acquires the currently idle handler runner thread, runs the
+-- function fn on it, and then releases the thread, returning it to being the
+-- currently idle one.
+-- If there was a currently idle runner thread already, that's okay, that old
+-- one will just get thrown and eventually GCed.
+local function acquireRunnerThreadAndCallEventHandler(fn, ...)
+	local acquiredRunnerThread = freeRunnerThread
+	freeRunnerThread = nil
+	fn(...)
+	-- The handler finished running, this runner thread is free again.
+	freeRunnerThread = acquiredRunnerThread
 end
 
-function Dis:Disconnect()
-	local Callbacks = self.Info.Callbacks
-	Callbacks[self.Index] = nil
-end
-
-function Signal:Connect(Func)
-	local Callbacks = self.Callbacks
-	local CallbackCount = #Callbacks
-	local Index = CallbackCount + 1
-	Callbacks[Index] = Func
-	local Data = setmetatable( {
-		["Info"] = self,
-		["Index"] = Index
-	} , Dis )
-	return Data
-end
-
-function Signal:Wait()
-	local Thread, Connection = coroutine.running()
-	Connection = self:Connect(function(...)
-		Connection:Disconnect()
-		Connection = nil
-		coroutine.resume(Thread, ...)
-	end)
-	return coroutine.yield(Thread)
-end
-
-function Signal:Fire(...)
-	local Callbacks = self.Callbacks
-	for _, Callback in ipairs(Callbacks) do
-		local _ = type(Callback) == "function" or error("Not a function")
-		Callback(...)
+-- Coroutine runner that we create coroutines of. The coroutine can be 
+-- repeatedly resumed with functions to run followed by the argument to run
+-- them with.
+local function runEventHandlerInFreeThread()
+	-- Note: We cannot use the initial set of arguments passed to
+	-- runEventHandlerInFreeThread for a call to the handler, because those
+	-- arguments would stay on the stack for the duration of the thread's
+	-- existence, temporarily leaking references. Without access to raw bytecode
+	-- there's no way for us to clear the "..." references from the stack.
+	while true do
+		acquireRunnerThreadAndCallEventHandler(coroutine.yield())
 	end
-
 end
+
+-- Connection class
+local Connection = {}
+Connection.__index = Connection
+
+function Connection.new(signal, fn)
+	return setmetatable({
+		_connected = true,
+		_signal = signal,
+		_fn = fn,
+		_next = false,
+	}, Connection)
+end
+
+function Connection:Disconnect()
+	self._connected = false
+
+	-- Unhook the node, but DON'T clear it. That way any fire calls that are
+	-- currently sitting on this node will be able to iterate forwards off of
+	-- it, but any subsequent fire calls will not hit it, and it will be GCed
+	-- when no more fire calls are sitting on it.
+	if self._signal._handlerListHead == self then
+		self._signal._handlerListHead = self._next
+	else
+		local prev = self._signal._handlerListHead
+		while prev and prev._next ~= self do
+			prev = prev._next
+		end
+		if prev then
+			prev._next = self._next
+		end
+	end
+end
+
+-- Make Connection strict
+setmetatable(Connection, {
+	__index = function(tb, key)
+		error(("Attempt to get Connection::%s (not a valid member)"):format(tostring(key)), 2)
+	end,
+	__newindex = function(tb, key, value)
+		error(("Attempt to set Connection::%s (not a valid member)"):format(tostring(key)), 2)
+	end
+})
+
+-- Signal class
+local Signal = {}
+Signal.__index = Signal
+
+function Signal.new()
+	return setmetatable({
+		_handlerListHead = false,
+	}, Signal)
+end
+
+function Signal:Connect(fn)
+	local connection = Connection.new(self, fn)
+	if self._handlerListHead then
+		connection._next = self._handlerListHead
+		self._handlerListHead = connection
+	else
+		self._handlerListHead = connection
+	end
+	return connection
+end
+
+-- Disconnect all handlers. Since we use a linked list it suffices to clear the
+-- reference to the head handler.
+function Signal:DisconnectAll()
+	self._handlerListHead = false
+end
+
+-- Signal:Fire(...) implemented by running the handler functions on the
+-- coRunnerThread, and any time the resulting thread yielded without returning
+-- to us, that means that it yielded to the Roblox scheduler and has been taken
+-- over by Roblox scheduling, meaning we have to make a new coroutine runner.
+function Signal:Fire(...)
+	local item = self._handlerListHead
+	while item do
+		if item._connected then
+			if not freeRunnerThread then
+				freeRunnerThread = coroutine.create(runEventHandlerInFreeThread)
+				-- Get the freeRunnerThread to the first yield
+				coroutine.resume(freeRunnerThread)
+			end
+			task.spawn(freeRunnerThread, item._fn, ...)
+		end
+		item = item._next
+	end
+end
+
+-- Implement Signal:Wait() in terms of a temporary connection using
+-- a Signal:Connect() which disconnects itself.
+function Signal:Wait()
+	local waitingCoroutine = coroutine.running()
+	local cn;
+	cn = self:Connect(function(...)
+		cn:Disconnect()
+		task.spawn(waitingCoroutine, ...)
+	end)
+	return coroutine.yield()
+end
+
+-- Implement Signal:Once() in terms of a connection which disconnects
+-- itself before running the handler.
+function Signal:Once(fn)
+	local cn;
+	cn = self:Connect(function(...)
+		if cn._connected then
+			cn:Disconnect()
+		end
+		fn(...)
+	end)
+	return cn
+end
+
+-- Make signal strict
+setmetatable(Signal, {
+	__index = function(tb, key)
+		error(("Attempt to get Signal::%s (not a valid member)"):format(tostring(key)), 2)
+	end,
+	__newindex = function(tb, key, value)
+		error(("Attempt to set Signal::%s (not a valid member)"):format(tostring(key)), 2)
+	end
+})
 
 return Signal

--- a/src/StarterGui/HUD/UiCore/init.client.lua
+++ b/src/StarterGui/HUD/UiCore/init.client.lua
@@ -32,7 +32,7 @@ local CachedModules = {}
 local connections = {}
 _G.SpaceAerial = true
 _G.CameraLock = false
-_G.DataSignal = Signal.New()
+_G.DataSignal = Signal.new()
 _G.FPS = 60
 
 for _, child in script:GetDescendants() do
@@ -140,7 +140,7 @@ RunService.Heartbeat:Connect(function()
 	FpsText.UIGradient.Color = ColorSequence.new(Color3.fromRGB(255, 255, 255), (Color3.new(255, 0, 0):Lerp(Color3.fromRGB(0, 255, 0), FpsText.Text / 50)));
 end)
 --]]
---[[_G.StateSignal = Signal.New()
+--[[_G.StateSignal = Signal.new()
 
 _G.StateSignal:Connect(function(Data)
 	local State, StateData = Data.ChosenState, Data.ChosenStateData

--- a/src/StarterPlayer/StarterPlayerScripts/Client/ClientState/init.client.lua
+++ b/src/StarterPlayer/StarterPlayerScripts/Client/ClientState/init.client.lua
@@ -26,7 +26,7 @@ local Character = Player.Character or Player.CharacterAdded:Wait()
 
 local Mouse = Player:GetMouse()
 
-_G.StateSignal = Signal.New()
+_G.StateSignal = Signal.new()
 
 _G.StateSignal:Connect(function(Data)
 	local State, StateData = Data.ChosenState, Data.ChosenStateData


### PR DESCRIPTION
1. Replaced old signal module with [stravant's GoodSignal](https://github.com/stravant/goodsignal/tree/master) and globally replaced all instances of "Signal.New()" with "Signal.new()"

2. Cached typewriter thread returned by `task.spawn` for cancellation prior to spawning a new animation to avoid overlapping animations. (See [CharacterSelect\typewrite](https://github.com/cyrus01337/narugoku-shipgundam/blob/signal-and-typewriter-rework/src/StarterPlayer/StarterPlayerScripts/Client/Core/Gui/CharacterSelect.lua#L27)). The function was also refactored to use [TextLabel.MaxVisibleGraphemes](https://create.roblox.com/docs/reference/engine/classes/TextLabel#MaxVisibleGraphemes) for the reasons listed in the article below:
https://devforum.roblox.com/t/typewriter-effect-new-property-maxvisiblegraphemes-live/1092043